### PR TITLE
Fix nil pointer dereference for binaries without build info

### DIFF
--- a/dial/user_agent.go
+++ b/dial/user_agent.go
@@ -8,10 +8,11 @@ import (
 func UserAgent() string {
 	cloudUserAgent := "yandex-cloud/go-sdk"
 
-	build, _ := debug.ReadBuildInfo()
 	version := "unknown"
-	if build.Main.Version != "" {
-		version = build.Main.Version
+	if build, ok := debug.ReadBuildInfo(); ok {
+		if build.Main.Version != "" {
+			version = build.Main.Version
+		}
 	}
 
 	return fmt.Sprintf("%s/%s", cloudUserAgent, version)


### PR DESCRIPTION
Some build system like `bazel` and `ya make` don't add build info to binary.